### PR TITLE
Enhanced the NIF for the first task

### DIFF
--- a/example_data/task1.ttl
+++ b/example_data/task1.ttl
@@ -3,138 +3,150 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix nif: <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .
-@prefix d0: <http://ontologydesignpatterns.org/ont/wikipedia/d0.owl>
-@prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#>
+@prefix d0: <http://ontologydesignpatterns.org/ont/wikipedia/d0.owl> .
+@prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
 @prefix oke: <http://www.ontologydesignpatterns.org/data/oke-challenge/task-1/> .
 @prefix dbpedia: <http://dbpedia.org/resource/> .
-@prefix dc: <http://purl.org/dc/elements/1.1/> 
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1>
-      a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#Context> ;
-      <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#isString>
-              "Florence May Harding studied at the National Art School in Sydney, and with Douglas Robert Dundas , but in effect had no formal training in either botany or art." .
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=0,161>
+        a               nif:RFC5147String , nif:String , nif:Context ;
+        nif:beginIndex  "0"^^xsd:nonNegativeInteger ;
+        nif:endIndex    "161"^^xsd:nonNegativeInteger ;
+        nif:isString    "Florence May Harding studied at the National Art School in Sydney, and with Douglas Robert Dundas , but in effect had no formal training in either botany or art."^^xsd:string .
 
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Florence_May_Harding>
      a        dul:Person ;
      rdfs:label "Florence May Harding"@en ;
-     dc:relation oke:0_20_Florence_May_Harding ;
      owl:sameAs dbpedia:Florence_May_Harding .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/0_20_Florence_May_Harding>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1> ;
-     nif:beginIndex "0"^^xsd:int ;
-     nif:endIndex "20"^^xsd:int .
-
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=0,20>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "Florence May Harding"^^xsd:string ;
+        nif:beginIndex        "0"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "20"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=0,161> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Florence_May_Harding> .
 
 <http://www.ontologydesignpatterns.org/data/oke-challenge/National_Art_School>
      a        dul:Organization ;
      rdfs:label "National Art School"@en ;
-     dc:relation oke:36_55_National_Art_School ;
      owl:sameAs dbpedia:National_Art_School .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/36_55_National_Art_School>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1> ;
-     nif:beginIndex "36"^^xsd:int ;
-     nif:endIndex "55"^^xsd:int .
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=36,55>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "National Art School"^^xsd:string ;
+        nif:beginIndex        "36"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "55"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=0,161> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/National_Art_School> .
 
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Sydney>
      a        d0:Location ;
      rdfs:label "Sydney"@en ;
-     dc:relation oke:59_65_Sydney ;
      owl:sameAs dbpedia:Sydney .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/59_65_Sydney>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1> ;
-     nif:beginIndex "59"^^xsd:int ;
-     nif:endIndex "65"^^xsd:int .
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=59,65>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "Sydney"^^xsd:string ;
+        nif:beginIndex        "59"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "65"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=0,161> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Sydney> .
 
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Douglas_Robert_Dundas>
      a        dul:Person ;
-     rdfs:label "Douglas Robert Dundas"@en ;
-     dc:relation oke:76_97_Douglas_Robert_Dundas .
+     rdfs:label "Douglas Robert Dundas"@en .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/76_97_Douglas_Robert_Dundas>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1> ;
-     nif:beginIndex "76"^^xsd:int ;
-     nif:endIndex "97"^^xsd:int .
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=59,65>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "Sydney"^^xsd:string ;
+        nif:beginIndex        "59"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "65"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-1#char=0,161> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Sydney> .
      
-<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2>
-      a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#Context> ;
-      <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#isString>
-              "Such notables include James Carville, who was the senior political adviser to Bill Clinton, and Donna Brazile, the campaign manager of the 2000 presidential campaign of Vice-President Al Gore." .     
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=0,192>
+        a               nif:RFC5147String , nif:String , nif:Context ;
+        nif:beginIndex  "0"^^xsd:nonNegativeInteger ;
+        nif:endIndex    "192"^^xsd:nonNegativeInteger ;
+        nif:isString    "Such notables include James Carville, who was the senior political adviser to Bill Clinton, and Donna Brazile, the campaign manager of the 2000 presidential campaign of Vice-President Al Gore."^^xsd:string .
 
 <http://www.ontologydesignpatterns.org/data/oke-challenge/James_Carville>
      a        dul:Person ;
      rdfs:label "James Carville"@en ;
-     dc:relation oke:22_36_James_Carville ;
      owl:sameAs dbpedia:James_Carville .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/22_36_James_Carville>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2> ;
-     nif:beginIndex "22"^^xsd:int ;
-     nif:endIndex "36"^^xsd:int .
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=22,36>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "James Carville"^^xsd:string ;
+        nif:beginIndex        "22"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "36"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=0,192> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/James_Carville> .
      
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Political_adviser>
      a        dul:Role ;
      rdfs:label "political adviser"@en ;
-     dc:relation oke:54_74_Political_adviser ;
      owl:sameAs dbpedia:Political_consulting .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/54_74_Political_adviser>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2> ;
-     nif:beginIndex "54"^^xsd:int ;
-     nif:endIndex "74"^^xsd:int .
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=57,74>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "political adviser"^^xsd:string ;
+        nif:beginIndex        "57"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "74"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=0,192> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Political_adviser> .
      
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Bill_Clinton>
      a        dul:Person ;
      rdfs:label "Bill Clinton"@en ;
-     dc:relation oke:78_90_Bill_Clinton ;
      owl:sameAs dbpedia:Bill_Clinton .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/78_90_Bill_Clinton>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2> ;
-     nif:beginIndex "78"^^xsd:int ;
-     nif:endIndex "90"^^xsd:int .
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=78,90>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "Bill Clinton"^^xsd:string ;
+        nif:beginIndex        "78"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "90"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=0,192> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Bill_Clinton> .
      
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Donna_Brazile>
      a        dul:Person ;
      rdfs:label "Donna Brazile"@en ;
-     dc:relation oke:96_109_Donna_Brazile ;
      owl:sameAs dbpedia:Donna_Brazile . 
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/96_109_Donna_Brazile>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2> ;
-     nif:beginIndex "96"^^xsd:int ;
-     nif:endIndex "109"^^xsd:int .     
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=96,109>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "Donna Brazile"^^xsd:string ;
+        nif:beginIndex        "96"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "109"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=0,192> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Donna_Brazile> .
      
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Campaign_manager>
      a        dul:Role ;
      rdfs:label "campaign manager"@en ;
-     dc:relation oke:115_131_Campaign_manager ;
      owl:sameAs dbpedia:Campaign_manager .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/115_131_Campaign_manager>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2> ;
-     nif:beginIndex "115"^^xsd:int ;
-     nif:endIndex "131"^^xsd:int .          
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=115,131>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "campaign manager"^^xsd:string ;
+        nif:beginIndex        "115"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "131"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=0,192> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Campaign_manager> .          
      
 <http://www.ontologydesignpatterns.org/data/oke-challenge/Al_Gore>
      a        dul:Person ;
-     rdfs:label "campaign manager"@en ;
+     rdfs:label "Al Gore"@en ;
      dc:relation oke:184_191_Al_Gore ;
      owl:sameAs dbpedia:Al_Gore .
 
-<http://www.ontologydesignpatterns.org/data/oke-challenge/184_191_Al_Gore>
-     a       <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#OffsetBasedString> ;
-     nif:referenceContext <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2> ;
-     nif:beginIndex "184"^^xsd:int ;
-     nif:endIndex "191"^^xsd:int .     
+<http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=184,191>
+        a                     nif:RFC5147String , nif:String ;
+        nif:anchorOf          "Al Gore"^^xsd:string ;
+        nif:beginIndex        "184"^^xsd:nonNegativeInteger ;
+        nif:endIndex          "191"^^xsd:nonNegativeInteger ;
+        nif:referenceContext  <http://www.ontologydesignpatterns.org/data/oke-challenge/sentence-2#char=0,192> ;
+        itsrdf:taIdentRef     <http://www.ontologydesignpatterns.org/data/oke-challenge/Al_Gore> .    


### PR DESCRIPTION
Fixed the NIF handling different problems:
- URIs were not as descibed by the NIF standard (e.g., the "#char=X,Y" were missing)
- added the begin and end indexes if they were missing
- corrected the datatype of the indexes
- added the correct way of referring to an entity mentioned by a string using itsrdf:taIdentRef
- removed the dc:relation properties because they are not needed anymore
